### PR TITLE
Make the example work out-of-the-box

### DIFF
--- a/openshift/templates/beego.json
+++ b/openshift/templates/beego.json
@@ -75,16 +75,11 @@
             "uri": "${SOURCE_REPOSITORY_URL}",
             "ref": "${SOURCE_REPOSITORY_REF}"
           },
-          "contextDir": "${CONTEXT_DIR}"
+          "contextDir": "${CONTEXT_DIR}",
+          "dockerfile": "FROM docker.io/library/golang:1.4.2-onbuild\nUSER nobody"
         },
         "strategy": {
-          "type": "Source",
-          "sourceStrategy": {
-            "from": {
-              "kind": "DockerImage",
-              "name": "docker.io/library/golang:1.4.2-onbuild"
-            }
-          }
+          "type": "Docker"
         },
         "output": {
           "to": {


### PR DESCRIPTION
By using a Docker build with an inline Dockerfile, we can set the user
to a non-root user and then builds will succeed, requiring no changes to
OpenShift configuration.

Fixes #3.
