### PR TITLE
Make example use its own packages

### DIFF
--- a/controllers/chatroom.go
+++ b/controllers/chatroom.go
@@ -21,7 +21,7 @@ import (
 	"github.com/astaxie/beego"
 	"github.com/gorilla/websocket"
 
-	"github.com/beego/samples/WebIM/models"
+	"github.com/openshift/golang-ex/models"
 )
 
 type Subscription struct {

--- a/controllers/longpolling.go
+++ b/controllers/longpolling.go
@@ -15,7 +15,7 @@
 package controllers
 
 import (
-	"github.com/beego/samples/WebIM/models"
+	"github.com/openshift/golang-ex/models"
 )
 
 // LongPollingController handles long polling requests.

--- a/controllers/websocket.go
+++ b/controllers/websocket.go
@@ -21,7 +21,7 @@ import (
 	"github.com/astaxie/beego"
 	"github.com/gorilla/websocket"
 
-	"github.com/beego/samples/WebIM/models"
+	"github.com/openshift/golang-ex/models"
 )
 
 // WebSocketController handles WebSocket requests.

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/astaxie/beego"
 	"github.com/beego/i18n"
 
-	"github.com/beego/samples/WebIM/controllers"
+	"github.com/openshift/golang-ex/controllers"
 )
 
 const (


### PR DESCRIPTION
We were referencing the original example's packages, what makes any changes to code in models and controllers to be ignored.
